### PR TITLE
Fix CitationMixin database initialization issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,10 +34,10 @@ Removed
 Fixed
 ~~~~~
 
-- Fixed ``CitationMixin._init_db()`` being called repeatedly on every
-  ``get_citation()`` or ``update_cache()`` call, which could cause SQLite
-  database lock issues when used by external packages. The database now
-  only initializes once when it doesn't exist.
+- Fixed ``CitationMixin._init_db()`` raising ``"file is not a database"``
+  in parallel test environments (e.g. pytest-xdist): corrupt leftover db
+  files are now detected and recreated, schema creation is idempotent, and
+  WAL journal mode is enabled for safer concurrent access.
 
 Security
 ~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,11 @@ Removed
 Fixed
 ~~~~~
 
+- Fixed ``CitationMixin._init_db()`` being called repeatedly on every
+  ``get_citation()`` or ``update_cache()`` call, which could cause SQLite
+  database lock issues when used by external packages. The database now
+  only initializes once when it doesn't exist.
+
 Security
 ~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog <https://keepachangelog.com/en/1.1.0/>`__, and this project
 adheres to `Semantic
 Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-`Unreleased <https://github.com/DeepPSP/bib_lookup/compare/v0.1.2...HEAD>`__
+`Unreleased <https://github.com/DeepPSP/bib_lookup/compare/v0.1.3...HEAD>`__
 ------------------------------------------------------------------------------------------------
 
 Added

--- a/bib_lookup/citation_mixin.py
+++ b/bib_lookup/citation_mixin.py
@@ -26,7 +26,17 @@ class CitationMixin(object):
     citation_cache = citation_cache_db
 
     def _init_db(self):
-        """Initialize sqlite db and migrate csv if exists."""
+        """Initialize sqlite db and migrate csv if exists.
+
+        This method only initializes the database if it doesn't exist yet.
+        """
+        # Only initialize if database doesn't exist
+        if self.citation_cache_db.exists():
+            return
+
+        # Ensure the cache directory exists
+        self.citation_cache_db.parent.mkdir(parents=True, exist_ok=True)
+
         conn = sqlite3.connect(self.citation_cache_db)
         cursor = conn.cursor()
         cursor.execute("""

--- a/bib_lookup/citation_mixin.py
+++ b/bib_lookup/citation_mixin.py
@@ -26,25 +26,36 @@ class CitationMixin(object):
     citation_cache = citation_cache_db
 
     def _init_db(self):
-        """Initialize sqlite db and migrate csv if exists.
-
-        This method only initializes the database if it doesn't exist yet.
-        """
-        # Only initialize if database doesn't exist
-        if self.citation_cache_db.exists():
-            return
-
-        # Ensure the cache directory exists
+        """Initialize sqlite db and migrate csv if exists."""
         self.citation_cache_db.parent.mkdir(parents=True, exist_ok=True)
+
+        # If the file exists but is not a valid SQLite database (e.g. left
+        # from a previously interrupted write), remove it and start fresh.
+        if self.citation_cache_db.exists():
+            try:
+                with sqlite3.connect(self.citation_cache_db) as _probe:
+                    _probe.execute("SELECT * FROM sqlite_master LIMIT 1")
+            except sqlite3.DatabaseError:
+                warnings.warn(
+                    f"Citation cache database is corrupt and will be recreated: {self.citation_cache_db}",
+                    UserWarning,
+                )
+                self.citation_cache_db.unlink()
 
         conn = sqlite3.connect(self.citation_cache_db)
         cursor = conn.cursor()
+        # WAL mode allows concurrent readers alongside a writer, reducing
+        # contention and corruption risk when multiple processes share the db.
+        cursor.execute("PRAGMA journal_mode=WAL")
+        # CREATE TABLE IF NOT EXISTS is idempotent: safe to call every time,
+        # including when multiple xdist workers race through this method.
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS citations (
                 doi TEXT PRIMARY KEY,
                 citation TEXT
             )
         """)
+        conn.commit()
 
         # Backward compatibility: Migrate CSV to SQLite
         if self.citation_cache_csv.exists():
@@ -63,7 +74,6 @@ class CitationMixin(object):
             except Exception as e:
                 warnings.warn(f"Failed to migrate CSV cache: {e}", UserWarning)
 
-        conn.commit()
         conn.close()
 
     def get_citation(

--- a/test/test_citation_mixin.py
+++ b/test/test_citation_mixin.py
@@ -444,3 +444,49 @@ def test_citation_mixin_coverage_gaps(monkeypatch, tmp_path, capsys):
     obj7 = YetAnotherClass()
     res = obj7.get_citation()
     assert res == ""
+
+
+def test_init_db_corrupt_file(monkeypatch, tmp_path):
+    """Test that a corrupt (non-SQLite) db file is detected, warned about, and recreated."""
+    db_path = tmp_path / "bib-lookup-cache.db"
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_db", db_path)
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache", db_path)
+
+    # Write garbage bytes — not a valid SQLite file
+    db_path.write_bytes(b"this is definitely not a sqlite database file")
+
+    obj = SomeClass()
+    with pytest.warns(UserWarning, match="corrupt"):
+        obj._init_db()
+
+    # File must be recreated as a valid SQLite database with the citations table
+    assert db_path.exists()
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='citations'")
+    assert cursor.fetchone() is not None
+    conn.close()
+
+
+def test_init_db_idempotent(monkeypatch, tmp_path):
+    """Test that _init_db() is safe to call multiple times (idempotent).
+
+    This exercises the path where the db file already exists and is valid —
+    simulating concurrent xdist workers both calling _init_db().
+    """
+    db_path = tmp_path / "bib-lookup-cache.db"
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_db", db_path)
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache", db_path)
+
+    obj = SomeClass()
+    obj._init_db()
+    obj._init_db()  # second call must not corrupt or raise
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='citations'")
+    assert cursor.fetchone() is not None, "citations table must survive repeated _init_db() calls"
+    # WAL mode should be set
+    cursor.execute("PRAGMA journal_mode")
+    assert cursor.fetchone()[0] == "wal"
+    conn.close()

--- a/test/test_citation_mixin.py
+++ b/test/test_citation_mixin.py
@@ -451,6 +451,7 @@ def test_init_db_corrupt_file(monkeypatch, tmp_path):
     db_path = tmp_path / "bib-lookup-cache.db"
     monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_db", db_path)
     monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache", db_path)
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_csv", tmp_path / "bib-lookup-cache.csv")
 
     # Write garbage bytes — not a valid SQLite file
     db_path.write_bytes(b"this is definitely not a sqlite database file")
@@ -477,6 +478,7 @@ def test_init_db_idempotent(monkeypatch, tmp_path):
     db_path = tmp_path / "bib-lookup-cache.db"
     monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_db", db_path)
     monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache", db_path)
+    monkeypatch.setattr(bib_lookup.CitationMixin, "citation_cache_csv", tmp_path / "bib-lookup-cache.csv")
 
     obj = SomeClass()
     obj._init_db()


### PR DESCRIPTION
## Problem

When used in external packages with `pytest-xdist` (parallel workers), ``CitationMixin._init_db()`` would
intermittently raise "file is not a database" at the ``CREATE TABLE IF NOT EXISTS`` line. Deleting the .db file
restored normal operation.

Two root causes:

1. Corrupt leftover file — if a test process is killed mid-write (Ctrl-C, timeout, OOM), SQLite may leave the
file in a partially-written state. On the next run the file exists but has an invalid header → SQLITE_NOTADB.
2. 0-byte race window — with ``xdist``, ``sqlite3.connect()`` creates the file immediately (0 bytes) but writes the
SQLite header lazily on the first execute(). A concurrent worker can open this 0-byte file and fail before the
header is committed.

A previous fix added ``if self.citation_cache_db.exists(): return``, which only pushed the error downstream (into
``get_citation()``) and introduced a new risk of no such table: citations when the file existed but was
empty/partial.

## Solution

- Always run ``CREATE TABLE IF NOT EXISTS`` — it is idempotent and SQLite's internal locking handles concurrent
callers correctly. The early-return guard is removed.
- Detect and recover from corrupt files — before connecting, probe the existing file with ``SELECT * FROM sqlite_master LIMIT 1``. If it raises ``sqlite3.DatabaseError``, warn and delete the file so it can be cleanly recreated.
- Enable ``WAL`` mode (``PRAGMA journal_mode=WAL``) — ``WAL`` allows multiple concurrent readers alongside a writer,
greatly reducing contention and corruption risk in parallel test environments.