### PR TITLE
ci: replace deprecated test-results-action with codecov-action@v6

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -55,7 +55,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }} # required
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: junit.xml
         report_type: test_results

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -43,17 +43,20 @@ jobs:
         pip list
     - name: Run test with pytest and collect coverage
       run: |
-        pytest --cov=bib_lookup --cov-report term-missing -vv -s test
+        pytest --cov=bib_lookup --cov-report term-missing --cov-report xml:coverage.xml --junitxml=junit.xml -vv -s test
     - name: Upload coverage to Codecov
       # Only upload coverage for Python ${MAIN_PYTHON_VERSION} and the event is not scheduled
       if: matrix.python-version == env.MAIN_PYTHON_VERSION && !contains(fromJson('["schedule"]'), github.event_name)
       uses: codecov/codecov-action@v6
       with:
+        files: coverage.xml
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
         token: ${{ secrets.CODECOV_TOKEN }} # required
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v5
       with:
+        files: junit.xml
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Replace the deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v6` as recommended by the deprecation warning.

## Changes

- Add `--cov-report xml:coverage.xml` and `--junitxml=junit.xml` flags to the pytest command to generate the required report files
- Replace `codecov/test-results-action@v1` with `codecov/codecov-action@v6` using `report_type: test_results`
- Explicitly specify `files: coverage.xml` for the coverage upload step and `files: junit.xml` for the test results step