### PR TITLE
fix: normalize raw BibTeX before pybtex parse to handle unquoted month names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,10 @@ Removed
 
 Fixed
 ~~~~~
+- Fixed ``--format text --style gbt`` (and other pybtex-backed styles) returning
+  ``Not Found`` for DOIs whose BibTeX contains unquoted full month names (e.g.
+  ``month=June``). The raw BibTeX is now normalised through ``_to_bib_item``
+  before handing it to pybtex's strict parser.
 - Extended month normalisation in ``BibItem.__normalize_fields`` to handle full
   English month names (e.g. ``july``, ``june``) and non-standard abbreviations
   (e.g. ``sept``) returned by some DOI/PubMed resolvers, in addition to the

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -583,7 +583,21 @@ class BibLookup(ReprMixin):
                 if style and style.lower() in self.supported_styles:
                     try:
                         # res is currently BibTeX string because we forced format="bibtex" in _obtain_feed_content
-                        # Now parse and format using our local style
+                        # Before handing the raw BibTeX to pybtex's strict parser,
+                        # normalise it through _to_bib_item so that unquoted month
+                        # names (e.g. ``month=June``) are converted to their numeric
+                        # form (``month = {6}``) — otherwise pybtex treats them as
+                        # undefined macros and raises an UndefinedMacro error.
+                        res = str(
+                            self._to_bib_item(
+                                res,
+                                idtf,
+                                align,
+                                ignore_fields=[],  # keep all fields; stripping is done below
+                                label=label,
+                                capitalize_title=capitalize_title,
+                            )
+                        )
 
                         # Parsing
                         bib_data = parse_string(res, bib_format="bibtex")

--- a/test/test_styles.py
+++ b/test/test_styles.py
@@ -548,3 +548,47 @@ def test_misc():
     assert BibLookup(verbose=0).max_names == 3
     for node in [ieee_pages, ieee_month, chicago_pages, chicago_date]:
         assert str(node.format_data({})) == ""
+
+
+def test_text_format_unquoted_full_month_name(monkeypatch):
+    """``--format text --style gbt`` (and other pybtex-backed styles) must not
+    return ``Not Found`` when the raw BibTeX contains an unquoted full month
+    name like ``month=June`` — pybtex treats bare words as macros and raises
+    ``UndefinedMacro`` unless the raw BibTeX is normalised beforehand."""
+
+    from bib_lookup import BibLookup
+
+    # Raw BibTeX as returned by some DOI resolvers (e.g. Springer via crossref)
+    RAW_WITH_UNQUOTED_MONTH = """@article{An_2018, title={Prediction of remaining useful life under different conditions using accelerated life testing data}, volume={32}, ISSN={1976-3824}, url={http://dx.doi.org/10.1007/s12206-018-0507-z}, DOI={10.1007/s12206-018-0507-z}, number={6}, journal={Journal of Mechanical Science and Technology}, publisher={Springer Science and Business Media LLC}, author={An, Dawn and Choi, Joo-Ho and Kim, Nam Ho}, year={2018}, month=June, pages={2497–2507} }"""
+
+    def _fake_obtain_feed_content(self, identifier, arxiv2doi=None, format=None, style=None, timeout=None):
+        return ("doi", {}, "10.1007/s12206-018-0507-z")
+
+    def _fake_handle_doi(self, feed_content):
+        return RAW_WITH_UNQUOTED_MONTH
+
+    monkeypatch.setattr(BibLookup, "_obtain_feed_content", _fake_obtain_feed_content)
+    monkeypatch.setattr(BibLookup, "_handle_doi", _fake_handle_doi)
+
+    bl = BibLookup(verbose=0)
+
+    # 1. GBT7714 style (uppercases author names per the standard)
+    result = bl("10.1007/s12206-018-0507-z", format="text", style="gbt", print_result=False)
+    assert result not in (None, "Not Found"), f"GBT7714 failed: {result!r}"
+    assert "Prediction" in result
+    assert "AN" in result  # GBT7714 uppercases surnames
+
+    # 2. IEEE style — same unquoted month should not break it
+    result_ieee = bl("10.1007/s12206-018-0507-z", format="text", style="ieee", print_result=False)
+    assert result_ieee not in (None, "Not Found"), f"IEEE failed: {result_ieee!r}"
+    assert "An" in result_ieee
+
+    # 3. APA style
+    result_apa = bl("10.1007/s12206-018-0507-z", format="text", style="apa", print_result=False)
+    assert result_apa not in (None, "Not Found"), f"APA failed: {result_apa!r}"
+    assert "An" in result_apa
+
+    # 4. Chicago style
+    result_chi = bl("10.1007/s12206-018-0507-z", format="text", style="chicago", print_result=False)
+    assert result_chi not in (None, "Not Found"), f"Chicago failed: {result_chi!r}"
+    assert "An" in result_chi


### PR DESCRIPTION
## Problem

`bib-lookup DOI --format text --style gbt` returned "Not Found" for DOIs whose raw BibTeX contains unquoted full month names like `month=June`.

pybtex's strict `parse_string` treats bare words as BibTeX macros, but only the standard 3-letter abbreviations (`jan`, `feb`, …) are pre-defined.  Full month names (`June`, `September`, etc.) raise `UndefinedMacro`, and the exception was silently caught and displayed as "Not Found".

The default bibtex format was unaffected because `_to_bib_item` → `BibItem.__normalize_fields` already normalizes months through `_MONTH_TO_INT`, but the text-format path bypassed this step.

## Fix

Pre-process the raw BibTeX string through the existing `_to_bib_item` method before handing it to pybtex's `parse_string`.  This converts `month=June` → `month = {6}` which pybtex parses without issue.

## Before / After

```
$ bib-lookup 10.1007/s12206-018-0507-z --format text --style gbt
Not Found          # before

$ bib-lookup 10.1007/s12206-018-0507-z --format text --style gbt
[1] AN D, CHOI J, KIM N H. Prediction of remaining useful life under different conditions using accelerated life testing data[J/OL]. Journal of Mechanical Science and Technology, 2018, 32(6): 2497-2507. DOI: 10.1007/s12206-018-0507-z.   # after
```

Co-Authored-By: DeepSeek V4 Pro