### PR TITLE
fix: preserve escaped percent signs and verbatim content in _remove_comments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,12 @@ Removed
 
 Fixed
 ~~~~~
+- Fixed ``_remove_comments`` incorrectly stripping escaped percent signs
+  (``\%``) and content following them when called with ``keep_comments=False``.
+  The function now uses a character-level state machine that correctly
+  distinguishes escaped ``%`` (preceded by an odd number of backslashes)
+  from comment-start ``%``, and preserves content inside ``\\verb|...|`` and
+  ``\\begin{verbatim}...\\end{verbatim}`` environments.
 - Fixed ``--format text --style gbt`` (and other pybtex-backed styles) returning
   ``Not Found`` for DOIs whose BibTeX contains unquoted full month names (e.g.
   ``month=June``). The raw BibTeX is now normalised through ``_to_bib_item``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,8 @@ Fixed
   (``\%``) and content following them when called with ``keep_comments=False``.
   The function now uses a character-level state machine that correctly
   distinguishes escaped ``%`` (preceded by an odd number of backslashes)
-  from comment-start ``%``, and preserves content inside ``\\verb|...|`` and
-  ``\\begin{verbatim}...\\end{verbatim}`` environments.
+  from comment-start ``%``, and preserves content inside ``\verb|...|`` and
+  ``\begin{verbatim}...\end{verbatim}`` environments.
 - Fixed ``--format text --style gbt`` (and other pybtex-backed styles) returning
   ``Not Found`` for DOIs whose BibTeX contains unquoted full month names (e.g.
   ``month=June``). The raw BibTeX is now normalised through ``_to_bib_item``

--- a/bib_lookup/utils.py
+++ b/bib_lookup/utils.py
@@ -446,6 +446,13 @@ def is_sub_interval(
 def _remove_comments(content: str) -> str:
     """Remove LaTeX comments from content.
 
+    Only ``%`` that is *not* preceded by an odd number of
+    consecutive backslashes is treated as a comment start;
+    ``\\%`` (escaped percent sign) is preserved, while
+    ``\\\\%`` (line break followed by a comment) is removed.
+    Content inside ``\\verb|...|`` and
+    ``\\begin{verbatim}...\\end{verbatim}`` is left untouched.
+
     Parameters
     ----------
     content : str
@@ -457,8 +464,47 @@ def _remove_comments(content: str) -> str:
         The LaTeX content without comments.
 
     """
-    comment_pattern = re.compile(r"%.*?$", re.MULTILINE)
-    return comment_pattern.sub("", content)
+    _VERBATIM_BLOCK = re.compile(r"\\begin\{verbatim\}(.*?)\\end\{verbatim\}", re.DOTALL)
+
+    def _clean_lines(text: str) -> str:
+        cleaned: List[str] = []
+        for line in text.splitlines():
+            chars: List[str] = []
+            escaped = False
+            i = 0
+            while i < len(line):
+                ch = line[i]
+                # \verb|...| or \verb*|...|  — copy verbatim
+                if ch == "\\" and (line[i:].startswith("\\verb*") or line[i:].startswith("\\verb")):
+                    cmd_len = 6 if line[i:].startswith("\\verb*") else 5
+                    if len(line) > i + cmd_len:
+                        delim = line[i + cmd_len]
+                        end = line.find(delim, i + cmd_len + 1)
+                        if end != -1:
+                            chars.append(line[i : end + 1])
+                            i = end + 1
+                            escaped = False
+                            continue
+                # \begin{verbatim}...  (block handled above; this catches
+                #   the \begin line itself)
+                if ch == "%" and not escaped:
+                    break
+                chars.append(ch)
+                escaped = not escaped if ch == "\\" else False
+                i += 1
+            cleaned.append("".join(chars))
+        return "\n".join(cleaned)
+
+    # Split on verbatim blocks: process each non-verbatim segment,
+    # copy verbatim blocks as-is.
+    parts = []
+    last = 0
+    for m in _VERBATIM_BLOCK.finditer(content):
+        parts.append(_clean_lines(content[last : m.start()]))
+        parts.append(m.group(0))  # verbatim block untouched
+        last = m.end()
+    parts.append(_clean_lines(content[last:]))
+    return "".join(parts)
 
 
 def gather_tex_source_files_in_one(

--- a/bib_lookup/utils.py
+++ b/bib_lookup/utils.py
@@ -468,7 +468,7 @@ def _remove_comments(content: str) -> str:
 
     def _clean_lines(text: str) -> str:
         cleaned: List[str] = []
-        for line in text.splitlines():
+        for line in text.split("\n"):
             chars: List[str] = []
             escaped = False
             i = 0

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -165,9 +165,8 @@ def test_remove_comments():
 
     # verbatim block: content untouched
     verbatim_inp = "text % comment\n" r"\begin{verbatim}" + "\n" "100% ok\n" r"\end{verbatim}" + "\n" "more % another"
-    # The cleaned non-verbatim segment may lose the trailing newline
-    # before the verbatim block; this does not affect LaTeX compilation.
-    verbatim_expected = "text " r"\begin{verbatim}" + "\n" "100% ok\n" r"\end{verbatim}" + "\n" "more "
+    # Newlines should be preserved when stripping comments.
+    verbatim_expected = "text \n" r"\begin{verbatim}" + "\n" "100% ok\n" r"\end{verbatim}" + "\n" "more "
     assert _remove_comments(verbatim_inp) == verbatim_expected
 
     # gather_tex_source_files_in_one with keep_comments=False

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from bib_lookup.utils import (
+    _remove_comments,
     capitalize_title,
     color_text,
     gather_tex_source_files_in_one,
@@ -134,6 +135,46 @@ def test_gather_tex_source_files_in_one():
         gather_tex_source_files_in_one(entry_file, write_file=True, output_file=output_file)
 
     gather_tex_source_files_in_one(entry_file, write_file=True, output_file=output_file, overwrite=True)
+
+
+def test_remove_comments():
+    """Test LaTeX comment removal edge cases."""
+    # Escaped percent (odd backslashes): preserved
+    assert _remove_comments(r"100\% positive") == r"100\% positive"
+    assert _remove_comments(r"CODE-15\% is large") == r"CODE-15\% is large"
+    assert _remove_comments(r"\\\%  three backslashes") == r"\\\%  three backslashes"
+
+    # Even backslashes followed by %: comment is removed
+    assert _remove_comments(r"hello\\% comment") == r"hello\\"
+    assert _remove_comments(r"text \\\\% comment") == r"text \\\\"
+    assert _remove_comments(r"\\\\% comment") == r"\\\\"
+
+    # Normal comments
+    assert _remove_comments("abc % this is a comment") == "abc "
+    assert _remove_comments("  % indented comment") == "  "
+    assert _remove_comments("% full line comment\nNext line") == "\nNext line"
+
+    # No comments
+    assert _remove_comments("No comments here") == "No comments here"
+
+    # \verb|...| preserves content including %
+    assert _remove_comments(r"\verb|100%| is not a comment") == r"\verb|100%| is not a comment"
+    assert _remove_comments(r"\verb*|100%| star variant") == r"\verb*|100%| star variant"
+    assert _remove_comments(r"\verb!100%! bang delimiter") == r"\verb!100%! bang delimiter"
+    assert _remove_comments(r"before \verb|100%| after % real comment") == r"before \verb|100%| after "
+
+    # verbatim block: content untouched
+    verbatim_inp = "text % comment\n" r"\begin{verbatim}" + "\n" "100% ok\n" r"\end{verbatim}" + "\n" "more % another"
+    # The cleaned non-verbatim segment may lose the trailing newline
+    # before the verbatim block; this does not affect LaTeX compilation.
+    verbatim_expected = "text " r"\begin{verbatim}" + "\n" "100% ok\n" r"\end{verbatim}" + "\n" "more "
+    assert _remove_comments(verbatim_inp) == verbatim_expected
+
+    # gather_tex_source_files_in_one with keep_comments=False
+    entry = _SAMPLE_DIR / "sample-source.tex"
+    ret = gather_tex_source_files_in_one(entry, keep_comments=False)
+    assert r"% comment line" not in ret
+    assert r"\verb|" in ret  # verbatim content preserved
 
 
 def test_capitalize_title():


### PR DESCRIPTION
## Problem

`_remove_comments` used a simple regex `%.*?$` to strip LaTeX comments, which incorrectly removed:
- Escaped percent signs (`\%`) and everything after them on the same line
- Content inside `\verb|...%` and `\begin{verbatim}...\end{verbatim}` environments

## Fix

Replaced the regex with a character-level state machine that correctly:
- Preserves `\%` (odd number of backslashes before `%`)
- Removes comments (even number of backslashes or none)
- Leaves `\verb|...|` and `\begin{verbatim}...\end{verbatim}` content untouched

## Changes

- `bib_lookup/utils.py`: Rewrote `_remove_comments`
- `test/test_utils.py`: Added comprehensive tests covering escaped percents, verbatim, and comment/non-comment cases

Co-Authored-By: DeepSeek V4 Pro