### PR TITLE
fix: handle missing journal in style templates; add format_err & parse_err

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
 Added
 ~~~~~
+- Added ``format_err`` (``"Format Error"``) and ``parse_err`` (``"Parse Error"``)
+  as dedicated error types on ``BibLookup``, with corresponding ``@property``
+  getters, to distinguish local processing failures from remote lookup failures.
 
 Changed
 ~~~~~~~
@@ -25,6 +28,13 @@ Removed
 
 Fixed
 ~~~~~
+- Fixed text format and bibtex exception handlers silently returning ``Not Found``
+  when local parsing or style rendering fails.  They now return ``Parse Error``
+  and ``Format Error (<style>): <details>`` respectively.
+- Fixed ``--format text --style gbt`` (and IEEE / Chicago) returning ``Not Found``
+  for DOIs whose ``@article`` entry has no ``journal`` field — common for preprints
+  from bioRxiv, medRxiv, etc.  The style templates now use
+  ``optional_field("journal")`` instead of the mandatory ``field("journal")``.
 - Fixed ``_remove_comments`` incorrectly stripping escaped percent signs
   (``\%``) and content following them when called with ``keep_comments=False``.
   The function now uses a character-level state machine that correctly

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -650,13 +650,13 @@ class BibLookup(ReprMixin):
                         res = BeautifulSoup(res, "html.parser").get_text()
 
         if self.verbose >= 1:
-            if res in self.lookup_errors:
+            if self._is_error(res):
                 print_func(process_text(res, self.__err_color, font_size=self.__err_fontsize))  # type: ignore
             else:
                 print(res)
         self.verbose = original_verbose
 
-        if res in self.lookup_errors and ignore_errors:
+        if self._is_error(res) and ignore_errors:
             res = ""
 
         if print_result:
@@ -1176,7 +1176,18 @@ class BibLookup(ReprMixin):
 
     @property
     def lookup_errors(self) -> List[str]:
-        return [self.default_err, self.network_err, self.timeout_err]
+        return [self.default_err, self.network_err, self.timeout_err, self.format_err, self.parse_err]
+
+    def _is_error(self, res: str) -> bool:
+        """Check whether *res* is any kind of error string.
+
+        Exact-match for static errors (``Not Found``, ``Network Error``, …)
+        and prefix-match for dynamic ones (``Format Error (<style>): …``).
+        Only meaningful for ``str`` results; non-strings are never errors.
+        """
+        if not isinstance(res, str):
+            return False
+        return res in self.lookup_errors or res.startswith(self.format_err) or res.startswith(self.parse_err)
 
     @property
     def ignore_fields(self) -> List[str]:

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -1178,7 +1178,7 @@ class BibLookup(ReprMixin):
     def lookup_errors(self) -> List[str]:
         return [self.default_err, self.network_err, self.timeout_err, self.format_err, self.parse_err]
 
-    def _is_error(self, res: str) -> bool:
+    def _is_error(self, res: object) -> bool:
         """Check whether *res* is any kind of error string.
 
         Exact-match for static errors (``Not Found``, ``Network Error``, …)

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -266,6 +266,8 @@ class BibLookup(ReprMixin):
         self.__default_err = "Not Found"
         self.__network_err = "Network Error"
         self.__timeout_err = "Timeout Error"
+        self.__format_err = "Format Error"
+        self.__parse_err = "Parse Error"
 
         self.__header_pattern = "^@(?P<entry_type>\\w+)\\{(?P<label>[^,]+)"
 
@@ -578,7 +580,7 @@ class BibLookup(ReprMixin):
                     if len(self.__cached_lookup_results) > self.__cache_limit:
                         self.__cached_lookup_results.popitem(last=False)
                 except Exception:  # pragma: no cover
-                    res = self.default_err
+                    res = self.parse_err
             elif format == "text":
                 if style and style.lower() in self.supported_styles:
                     try:
@@ -640,7 +642,7 @@ class BibLookup(ReprMixin):
                     except Exception as e:  # pragma: no cover
                         if self.verbose > 0:
                             print(f"Error formatting with local style {style}: {e}")
-                        res = self.default_err
+                        res = f"{self.format_err} ({style}): {e}"
                 else:
                     # Original text handling
                     with warnings.catch_warnings():
@@ -1163,6 +1165,14 @@ class BibLookup(ReprMixin):
     @property
     def timeout_err(self) -> str:
         return self.__timeout_err
+
+    @property
+    def format_err(self) -> str:
+        return self.__format_err
+
+    @property
+    def parse_err(self) -> str:
+        return self.__parse_err
 
     @property
     def lookup_errors(self) -> List[str]:

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -579,17 +579,15 @@ class BibLookup(ReprMixin):
                     self.__cached_lookup_results[identifier] = res
                     if len(self.__cached_lookup_results) > self.__cache_limit:
                         self.__cached_lookup_results.popitem(last=False)
-                except Exception:  # pragma: no cover
-                    res = self.parse_err
+                except Exception as e:  # pragma: no cover
+                    res = f"{self.parse_err}: {e}"
             elif format == "text":
                 if style and style.lower() in self.supported_styles:
+                    # --- parse phase ---
+                    # Normalise the raw BibTeX (handles unquoted month names,
+                    # etc.) and parse with pybtex.  Failures here are parse
+                    # errors, not format errors.
                     try:
-                        # res is currently BibTeX string because we forced format="bibtex" in _obtain_feed_content
-                        # Before handing the raw BibTeX to pybtex's strict parser,
-                        # normalise it through _to_bib_item so that unquoted month
-                        # names (e.g. ``month=June``) are converted to their numeric
-                        # form (``month = {6}``) — otherwise pybtex treats them as
-                        # undefined macros and raises an UndefinedMacro error.
                         res = str(
                             self._to_bib_item(
                                 res,
@@ -600,49 +598,46 @@ class BibLookup(ReprMixin):
                                 capitalize_title=capitalize_title,
                             )
                         )
-
-                        # Parsing
                         bib_data = parse_string(res, bib_format="bibtex")
-
-                        # Remove ignored fields before formatting
-                        if self._ignore_fields:
-                            for entry in bib_data.entries.values():
-                                for field in self._ignore_fields:
-                                    if field in entry.fields:
-                                        del entry.fields[field]
-
-                        # Formatting
-                        style_class = self.supported_styles[style.lower()]
-                        # Use style-specific defaults for max_names unless user explicitly configured it
-                        # Default max_names: GBT=3, IEEE=6, APA=20, Chicago=10
-                        style_defaults = {"gbt7714": 3, "gbt": 3, "gbt-7714": 3, "ieee": 6, "apa": 20, "chicago": 10}
-                        style_default_max = style_defaults.get(style.lower(), 3)
-
-                        # Only pass max_names if user explicitly configured it (different from global default of 3)
-                        if self.max_names != 3 or style.lower() in ["gbt7714", "gbt", "gbt-7714"]:
-                            custom_style = style_class(max_names=self.max_names)
-                        else:
-                            custom_style = style_class()
-                        formatted_entries = custom_style.format_entries(bib_data.entries.values())
-
-                        backend = TextBackend()
-                        output = io.StringIO()
-
-                        # Write all entries (usually just one)
-                        for entry in formatted_entries:
-                            backend.write_to_stream([entry], output)
-
-                        res = output.getvalue().strip()
-
-                        # Strip labels like [1] or [ ] if the style returns an empty label
-                        # but the backend still adds brackets.
-                        if style.lower() in ["apa", "chicago"]:
-                            res = re.sub(r"^\[\d*\]\s*", "", res)
-
                     except Exception as e:  # pragma: no cover
                         if self.verbose > 0:
-                            print(f"Error formatting with local style {style}: {e}")
-                        res = f"{self.format_err} ({style}): {e}"
+                            print(f"Error parsing BibTeX: {e}")
+                        res = f"{self.parse_err}: {e}"
+                    else:
+                        # --- format phase ---
+                        try:
+                            # Remove ignored fields before formatting
+                            if self._ignore_fields:
+                                for entry in bib_data.entries.values():
+                                    for field in self._ignore_fields:
+                                        if field in entry.fields:
+                                            del entry.fields[field]
+
+                            style_class = self.supported_styles[style.lower()]
+                            style_defaults = {"gbt7714": 3, "gbt": 3, "gbt-7714": 3, "ieee": 6, "apa": 20, "chicago": 10}
+                            style_default_max = style_defaults.get(style.lower(), 3)
+
+                            if self.max_names != 3 or style.lower() in ["gbt7714", "gbt", "gbt-7714"]:
+                                custom_style = style_class(max_names=self.max_names)
+                            else:
+                                custom_style = style_class()
+                            formatted_entries = custom_style.format_entries(bib_data.entries.values())
+
+                            backend = TextBackend()
+                            output = io.StringIO()
+                            for entry in formatted_entries:
+                                backend.write_to_stream([entry], output)
+
+                            res = output.getvalue().strip()
+
+                            # Strip empty labels like [1] or [ ]
+                            if style.lower() in ["apa", "chicago"]:
+                                res = re.sub(r"^\[\d*\]\s*", "", res)
+
+                        except Exception as e:  # pragma: no cover
+                            if self.verbose > 0:
+                                print(f"Error formatting with local style {style}: {e}")
+                            res = f"{self.format_err} ({style}): {e}"
                 else:
                     # Original text handling
                     with warnings.catch_warnings():

--- a/bib_lookup/styles/chicago.py
+++ b/bib_lookup/styles/chicago.py
@@ -180,7 +180,7 @@ class ChicagoStyle(UnsrtStyle):
         if e.fields.get("volume"):
             # With volume: Journal Vol, no. N (Month Year): Pages
             journal_info = join(sep=" ")[
-                tag("em")[field("journal")],
+                tag("em")[optional_field("journal")],
                 join(sep="")[
                     optional_field("volume"),
                     optional[join(sep="")[", no. ", field("number")]],
@@ -192,7 +192,7 @@ class ChicagoStyle(UnsrtStyle):
         else:
             # Without volume: Journal, Month Year, Pages (comma-separated, no parens)
             journal_info = join(sep=", ")[
-                tag("em")[field("journal")],
+                tag("em")[optional_field("journal")],
                 chicago_date_plain,
                 chicago_pages,
             ]

--- a/bib_lookup/styles/gbt7714.py
+++ b/bib_lookup/styles/gbt7714.py
@@ -139,7 +139,7 @@ class GBT7714Style(UnsrtStyle):
             self.format_names("author", as_sentence=False),
             join[field("title"), medium_tag],
             join(sep=", ")[
-                field("journal"),
+                optional_field("journal"),
                 gbt_year_vol_pages,
             ],
         ]

--- a/bib_lookup/styles/ieee.py
+++ b/bib_lookup/styles/ieee.py
@@ -204,7 +204,7 @@ class IEEEStyle(UnsrtStyle):
             template = join(sep=" ")[
                 self.format_names("author", as_sentence=False, use_first_author_full=True),
                 join(sep="")[join(sep="")["“", field("title"), "”", "."]],
-                join(sep="")["In: ", tag("em")[optional_field("journal")]],
+                optional[join(sep="")["In: ", tag("em")[field("journal")]]],
                 join(sep="")[
                     optional_field("volume"),
                     " (",

--- a/bib_lookup/styles/ieee.py
+++ b/bib_lookup/styles/ieee.py
@@ -204,7 +204,7 @@ class IEEEStyle(UnsrtStyle):
             template = join(sep=" ")[
                 self.format_names("author", as_sentence=False, use_first_author_full=True),
                 join(sep="")[join(sep="")["“", field("title"), "”", "."]],
-                join(sep="")["In: ", tag("em")[field("journal")]],
+                join(sep="")["In: ", tag("em")[optional_field("journal")]],
                 join(sep="")[
                     optional_field("volume"),
                     " (",
@@ -223,7 +223,7 @@ class IEEEStyle(UnsrtStyle):
             # Standard format: [1] H. Wen and J. Kang, "Title," Journal, vol. 43, no. 11, p. 115 006, Nov. 2022, ISSN: ...
             template = join(sep=", ")[
                 self.format_names("author", as_sentence=False, use_first_author_full=False),
-                join(sep=" ")[join(sep="")["“", field("title"), ",”"], tag("em")[field("journal")]],
+                join(sep=" ")[join(sep="")["“", field("title"), ",”"], tag("em")[optional_field("journal")]],
                 optional[words["vol.", field("volume")]],
                 optional[words["no.", field("number")]],
                 optional[ieee_pages],

--- a/test/test_styles.py
+++ b/test/test_styles.py
@@ -592,3 +592,34 @@ def test_text_format_unquoted_full_month_name(monkeypatch):
     result_chi = bl("10.1007/s12206-018-0507-z", format="text", style="chicago", print_result=False)
     assert result_chi not in (None, "Not Found"), f"Chicago failed: {result_chi!r}"
     assert "An" in result_chi
+
+
+def test_text_format_missing_journal(monkeypatch):
+    """``--format text --style ...`` must not crash (or silently return
+    an error) when the ``@article`` entry has no ``journal`` field —
+    e.g. preprints from bioRxiv / medRxiv."""
+
+    from bib_lookup import BibLookup
+
+    # @article without journal (typical for preprint servers)
+    RAW_NO_JOURNAL = """@article{Chan_2025, title={ENTAgents: AI Agents for Complex Knowledge Otolaryngology}, url={http://dx.doi.org/10.1101/2025.01.01.25319863}, DOI={10.1101/2025.01.01.25319863}, publisher={openRxiv}, author={Chan, Tsz Kin and Dinh, Ngoc-Duy}, year={2025}, month={1} }"""
+
+    def _fake_obtain_feed_content(self, identifier, arxiv2doi=None, format=None, style=None, timeout=None):
+        return ("doi", {}, "10.1101/2025.01.01.25319863")
+
+    def _fake_handle_doi(self, feed_content):
+        return RAW_NO_JOURNAL
+
+    monkeypatch.setattr(BibLookup, "_obtain_feed_content", _fake_obtain_feed_content)
+    monkeypatch.setattr(BibLookup, "_handle_doi", _fake_handle_doi)
+
+    bl = BibLookup(verbose=0)
+
+    for style in ["gbt", "ieee", "apa", "chicago"]:
+        result = bl("10.1101/2025.01.01.25319863", format="text", style=style, print_result=False)
+        assert result is not None, f"{style}: result is None"
+        assert result not in bl.lookup_errors, f"{style}: got lookup error {result!r}"
+        assert not result.startswith("Format Error"), f"{style}: format error: {result!r}"
+        assert (
+            "ENTAgents" in result or "Entagents" in result or "Chan" in result
+        ), f"{style}: output doesn't contain expected text: {result!r}"

--- a/test/test_styles.py
+++ b/test/test_styles.py
@@ -623,3 +623,8 @@ def test_text_format_missing_journal(monkeypatch):
         assert (
             "ENTAgents" in result or "Entagents" in result or "Chan" in result
         ), f"{style}: output doesn't contain expected text: {result!r}"
+
+        # IEEE compact format must not leave an orphan "In:" when
+        # journal is missing.
+        if style == "ieee" and "In: " in result:
+            assert "In:  (" not in result, f"ieee: orphan 'In:' without journal: {result!r}"


### PR DESCRIPTION
## Problem 1

DOIs from bioRxiv/medRxiv (e.g. `10.1101/2025.01.01.25319863`) return `@article` without a `journal` field. pybtex's `field("journal")` raises `FieldIsMissing`, caught as "Not Found".

## Problem 2

The text format and bibtex exception handlers returned "Not Found" even when the DOI was resolved but local formatting/parsing failed — misleading.

## Changes

- `field("journal")` → `optional_field("journal")` in GBT7714, IEEE, Chicago (APA already had it)
- Added `format_err` and `parse_err` error types, handlers now use them instead of `default_err`
- Test: `test_text_format_missing_journal` covers all 4 styles

## Before / After

```
$ bib-lookup 10.1101/2025.01.01.25319863 --format text --style gbt
Not Found           # before

$ bib-lookup 10.1101/2025.01.01.25319863 --format text --style gbt
[1] CHAN T K, DINH N. ENTAgents: ...   # after
```

Co-Authored-By: DeepSeek V4 Pro