### PR TITLE
feat: add gbmedium config, set CLI subcommand, and config warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,24 @@ Added
 - Added ``format_err`` (``"Format Error"``) and ``parse_err`` (``"Parse Error"``)
   as dedicated error types on ``BibLookup``, with corresponding ``@property``
   getters, to distinguish local processing failures from remote lookup failures.
+- Added ``set`` subcommand to the CLI (``bib-lookup set KEY VALUE``) for setting
+  individual configuration values; ``VALUE`` of ``none``/``null`` resets the key
+  to ``None`` (falling back to built-in logic).
+- Added ``gbmedium`` configuration option for the GB/T 7714-2015 style:
+  ``True`` forces ``[J/OL]`` (online), ``False`` forces ``[J]`` (print),
+  ``None`` (default) auto-detects based on the presence of ``doi``/``url`` fields.
+- Added ``STYLE_PARAMETERS`` registry in ``_const.py`` documenting per-style
+  configuration parameters, used for validation in ``--config`` and ``set``.
 
 Changed
 ~~~~~~~
+- ``--config`` now warns (instead of silently discards) when unknown keys are
+  encountered; the keys are still written to the config file.
+- ``str2bool`` now passes ``None`` through unchanged so that config values
+  reset to ``None`` work correctly for boolean fields.
+- Style-specific settings are now collected in a ``_style_kwargs`` dictionary
+  inside ``BibLookup`` (populated by ``_init_style_kwargs``) rather than as
+  individual attributes, making it easy to add new per-style parameters.
 
 Deprecated
 ~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -154,7 +154,16 @@ bib-lookup --config /path/to/config.json
 bib-lookup --config /path/to/config.yaml
 ```
 
-Note that unrecognized fields will be ignored and warning messages will be printed. The following table lists all the available configuration options:
+Set a single configuration value (new shortcut):
+
+```bash
+bib-lookup set timeout 2.0
+bib-lookup set style gbt
+bib-lookup set gbmedium true   # reset a key to its built-in default with "none"
+bib-lookup set gbmedium none
+```
+
+Note that unrecognized fields will trigger a warning but are still written to the configuration file. The following table lists all the available configuration options:
 
 | Option          | Type    | Default                                       | Description                                         |
 |-----------------|---------|-----------------------------------------------|-----------------------------------------------------|
@@ -169,6 +178,7 @@ Note that unrecognized fields will be ignored and warning messages will be print
 | `verbose`       | `int`   | `0`                                           | Verbosity level.                                    |
 | `print_result`  | `bool`  | `False`                                       | Whether to print the result.                        |
 | `ordering`      | `list`  | `['title', 'author', 'journal', 'booktitle']` | Ordering of the fields.                             |
+| `gbmedium`      | `bool`  | `None`                                        | (**GB/T 7714 only**) Medium tag for articles: `True` forces `[J/OL]`, `False` forces `[J]`, `None` auto-detects from DOI/URL fields. |
 
 :point_right: [Back to TOC](#bib_lookup)
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Set a single configuration value (new shortcut):
 ```bash
 bib-lookup set timeout 2.0
 bib-lookup set style gbt
-bib-lookup set gbmedium true   # reset a key to its built-in default with "none"
-bib-lookup set gbmedium none
+bib-lookup set gbmedium true   # force [J/OL] for all articles
+bib-lookup set gbmedium none   # reset to built-in auto-detection
 ```
 
 Note that unrecognized fields will trigger a warning but are still written to the configuration file. The following table lists all the available configuration options:

--- a/bib_lookup/_const.py
+++ b/bib_lookup/_const.py
@@ -24,4 +24,27 @@ DEFAULT_CONFIG = dict(
     cache_limit=1e6,
     capitalize_title=False,
     max_names=3,
+    gbmedium=None,
 )
+
+# Style-specific parameters documentation.
+# These parameters are passed to the style class constructor
+# when the corresponding style is active, and are recognised
+# by the `set` and `--config` commands in addition to the keys
+# in DEFAULT_CONFIG above.
+STYLE_PARAMETERS = {
+    "gbt7714": {
+        "gbmedium": {
+            "type": "bool_or_none",
+            "default": None,
+            "description": (
+                "Medium type tag for articles in GB/T 7714 style. "
+                "True -> [J/OL] (online), False -> [J] (print), "
+                "None -> auto-detect based on presence of DOI/URL fields."
+            ),
+        },
+    },
+    "ieee": {},
+    "apa": {},
+    "chicago": {},
+}

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -308,6 +308,12 @@ class BibLookup(ReprMixin):
         if self.max_names < 1:
             raise ValueError(f"`max_names` must be an integer >= 1, but got `{max_names_raw}`")
 
+        # Style-specific settings collected into a dict mapping style name → kwargs.
+        # This keeps BibLookup free of per-setting attributes and makes it easy
+        # to add new style-specific parameters in the future.
+        self._style_kwargs: Dict[str, dict] = {}
+        self._init_style_kwargs(bl_config)
+
         self.__field_pattern = f""",\\s*({"|".join(list(BIB_FIELDS))})\\s*=\\s*"""
 
         self.__info_color = "blue"
@@ -394,6 +400,23 @@ class BibLookup(ReprMixin):
             pass
 
         return supported_styles
+
+    def _init_style_kwargs(self, bl_config: dict) -> None:
+        """Populate ``self._style_kwargs`` from the merged config.
+
+        This dict maps normalised style names to the extra keyword arguments
+        that should be passed to the corresponding style class constructor.
+        It is the single place to add new style-specific settings.
+        """
+        # gbmedium for GB/T 7714
+        gbmedium_raw = bl_config.get("gbmedium", None)
+        if gbmedium_raw is not None and not (isinstance(gbmedium_raw, str) and gbmedium_raw.lower() in ("none", "null")):
+            _gbmedium_val = str2bool(gbmedium_raw)
+            self._style_kwargs = {
+                "gbt7714": {"gbmedium": _gbmedium_val},
+                "gbt": {"gbmedium": _gbmedium_val},
+                "gbt-7714": {"gbmedium": _gbmedium_val},
+            }
 
     def __call__(
         self,
@@ -614,13 +637,14 @@ class BibLookup(ReprMixin):
                                             del entry.fields[field]
 
                             style_class = self.supported_styles[style.lower()]
-                            style_defaults = {"gbt7714": 3, "gbt": 3, "gbt-7714": 3, "ieee": 6, "apa": 20, "chicago": 10}
-                            style_default_max = style_defaults.get(style.lower(), 3)
 
+                            # Build kwargs for the style constructor:
+                            # merge max_names logic with any style-specific settings
+                            _style_kwargs = dict(self._style_kwargs.get(style.lower(), {}))
                             if self.max_names != 3 or style.lower() in ["gbt7714", "gbt", "gbt-7714"]:
-                                custom_style = style_class(max_names=self.max_names)
-                            else:
-                                custom_style = style_class()
+                                _style_kwargs.setdefault("max_names", self.max_names)
+
+                            custom_style = style_class(**_style_kwargs)
                             formatted_entries = custom_style.format_entries(bib_data.entries.values())
 
                             backend = TextBackend()

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -890,10 +890,11 @@ class BibLookup(ReprMixin):
         if res in self.lookup_errors:
             return res
 
-        # If we asked for BibTeX but the response does not look like BibTeX,
-        # the server ignored our Accept header (returned HTML, a redirect page, etc.)
-        # — treat this as a network error rather than returning garbage to the parser.
-        if is_requesting_bibtex and not res.strip().startswith("@"):
+        # If we asked for BibTeX but the response looks like HTML,
+        # the server ignored our Accept header (returned a landing page,
+        # redirect page, error page, etc.) — treat this as a network error
+        # rather than returning raw HTML to the BibTeX parser.
+        if is_requesting_bibtex and re.match(r"\s*<(!DOCTYPE|html)", res, re.IGNORECASE):
             return self.network_err
 
         if res:

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -890,8 +890,12 @@ class BibLookup(ReprMixin):
         if res in self.lookup_errors:
             return res
 
-        # If we successfully got content (even if it doesn't look like BibTeX but wasn't an error), return it.
-        # This handles the case where we asked for BibTeX, got something else (200 OK), fallback skipped (no doi.org), and we just return what we got.
+        # If we asked for BibTeX but the response does not look like BibTeX,
+        # the server ignored our Accept header (returned HTML, a redirect page, etc.)
+        # — treat this as a network error rather than returning garbage to the parser.
+        if is_requesting_bibtex and not res.strip().startswith("@"):
+            return self.network_err
+
         if res:
             return res
 

--- a/bib_lookup/bib_lookup.py
+++ b/bib_lookup/bib_lookup.py
@@ -406,17 +406,16 @@ class BibLookup(ReprMixin):
 
         This dict maps normalised style names to the extra keyword arguments
         that should be passed to the corresponding style class constructor.
-        It is the single place to add new style-specific settings.
+        It is the single place to add new style-specific settings.  Each
+        block updates ``self._style_kwargs`` in place so that adding new
+        style-specific settings does not clobber existing ones.
         """
         # gbmedium for GB/T 7714
         gbmedium_raw = bl_config.get("gbmedium", None)
         if gbmedium_raw is not None and not (isinstance(gbmedium_raw, str) and gbmedium_raw.lower() in ("none", "null")):
             _gbmedium_val = str2bool(gbmedium_raw)
-            self._style_kwargs = {
-                "gbt7714": {"gbmedium": _gbmedium_val},
-                "gbt": {"gbmedium": _gbmedium_val},
-                "gbt-7714": {"gbmedium": _gbmedium_val},
-            }
+            for _name in ("gbt7714", "gbt", "gbt-7714"):
+                self._style_kwargs.setdefault(_name, {})["gbmedium"] = _gbmedium_val
 
     def __call__(
         self,
@@ -603,7 +602,8 @@ class BibLookup(ReprMixin):
                     if len(self.__cached_lookup_results) > self.__cache_limit:
                         self.__cached_lookup_results.popitem(last=False)
                 except Exception as e:  # pragma: no cover
-                    res = f"{self.parse_err}: {e}"
+                    _truncated = res if len(res) <= 200 else res[:200] + "..."
+                    res = f"{self.parse_err} ({idtf}): {e}\n  Input: {_truncated}"
             elif format == "text":
                 if style and style.lower() in self.supported_styles:
                     # --- parse phase ---
@@ -625,7 +625,8 @@ class BibLookup(ReprMixin):
                     except Exception as e:  # pragma: no cover
                         if self.verbose > 0:
                             print(f"Error parsing BibTeX: {e}")
-                        res = f"{self.parse_err}: {e}"
+                        _truncated = res if len(res) <= 200 else res[:200] + "..."
+                        res = f"{self.parse_err} ({idtf}): {e}\n  Input: {_truncated}"
                     else:
                         # --- format phase ---
                         try:

--- a/bib_lookup/cli.py
+++ b/bib_lookup/cli.py
@@ -36,7 +36,7 @@ def _parse_config_value(value: str) -> Any:
 
     - ``none``/``null`` → ``None``
     - booleans (``true``/``false``/``yes``/``no``/…) → ``bool``
-    - ``[a, b, c]`` → ``list``
+    - ``[a, b, c]`` → ``list`` (quotes stripped, empty list ``[]`` handled)
     - otherwise → ``str``
     """
     if value.lower() in ("none", "null"):
@@ -46,7 +46,10 @@ def _parse_config_value(value: str) -> Any:
     except ValueError:
         pass
     if value.startswith("[") and value.endswith("]"):
-        return [v.strip() for v in value.strip("[]").split(",")]
+        inner = value.strip("[]").strip()
+        if not inner:
+            return []
+        return [v.strip().strip("'\"") for v in inner.split(",")]
     return value
 
 
@@ -90,10 +93,11 @@ def _handle_config(config_arg: str) -> None:
         return
     else:
         if "=" in config_arg:
-            config = dict([kv.strip().split("=") for kv in config_arg.split(";")])
+            config = {k.strip(): _parse_config_value(v.strip()) for k, v in (kv.split("=", 1) for kv in config_arg.split(";"))}
         else:
             config_path = Path(config_arg)
-            assert config_path.is_file(), f"Configuration file ``{config_arg}`` does not exist. Please check and try again."
+            if not config_path.is_file():
+                raise ValueError(f"Configuration file ``{config_arg}`` does not exist. Please check and try again.")
 
             if config_path.suffix == ".json":
                 config = json.loads(config_path.read_text())

--- a/bib_lookup/cli.py
+++ b/bib_lookup/cli.py
@@ -8,7 +8,7 @@ import json
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 try:
     import yaml
@@ -17,9 +17,49 @@ except ImportError:
 
 from bib_lookup._const import CONFIG_FILE as _CONFIG_FILE
 from bib_lookup._const import DEFAULT_CONFIG as _DEFAULT_CONFIG
+from bib_lookup._const import STYLE_PARAMETERS as _STYLE_PARAMETERS
 from bib_lookup.bib_lookup import BibLookup
 from bib_lookup.utils import str2bool
 from bib_lookup.version import __version__ as bl_version
+
+
+def _valid_config_keys() -> set:
+    """Return the set of all recognised configuration keys."""
+    keys = set(_DEFAULT_CONFIG.keys())
+    for style_params in _STYLE_PARAMETERS.values():
+        keys.update(style_params.keys())
+    return keys
+
+
+def _parse_config_value(value: str) -> Any:
+    """Parse a string config value into the appropriate Python type.
+
+    - ``none``/``null`` → ``None``
+    - booleans (``true``/``false``/``yes``/``no``/…) → ``bool``
+    - ``[a, b, c]`` → ``list``
+    - otherwise → ``str``
+    """
+    if value.lower() in ("none", "null"):
+        return None
+    try:
+        return str2bool(value)
+    except ValueError:
+        pass
+    if value.startswith("[") and value.endswith("]"):
+        return [v.strip() for v in value.strip("[]").split(",")]
+    return value
+
+
+def _read_user_config() -> dict:
+    """Read the user config file, returning an empty dict if it does not exist."""
+    if _CONFIG_FILE.is_file():
+        return json.loads(_CONFIG_FILE.read_text())
+    return {}
+
+
+def _write_user_config(config: dict) -> None:
+    """Write the config dict to the user config file."""
+    _CONFIG_FILE.write_text(json.dumps(config, indent=4))
 
 
 def _handle_config(config_arg: str) -> None:
@@ -68,22 +108,48 @@ def _handle_config(config_arg: str) -> None:
                     f"Unknown configuration file type ``{config_path.suffix}``. " "Only json and yaml files are supported."
                 )
 
-        # discard unknown keys
-        unknown_keys = set(config.keys()) - set(_DEFAULT_CONFIG.keys())
-        config = {k: v for k, v in config.items() if k in _DEFAULT_CONFIG}
-        # parse lists in the config
-        for k, v in config.items():
-            if isinstance(v, str) and v.startswith("[") and v.endswith("]"):
-                config[k] = [vv.strip() for vv in v.strip("[]").split(",")]
+        # Warn about unknown keys (but keep them — they may be style-specific)
+        unknown_keys = set(config.keys()) - _valid_config_keys()
         if len(unknown_keys) > 0:
             verb = "are" if len(unknown_keys) > 1 else "is"
             warnings.warn(
-                f"Unknown configuration keys ``{unknown_keys}`` {verb} discarded.",
+                f"Unknown configuration keys ``{unknown_keys}`` {verb} kept but might have no effect.",
                 RuntimeWarning,
             )
+
+        # Merge with existing user config and write back
+        existing = _read_user_config()
+        existing.update(config)
+        _write_user_config(existing)
         print(f"Setting configurations:\n{json.dumps(config, indent=4)}")
-        _CONFIG_FILE.write_text(json.dumps(config, indent=4))
         return
+
+
+def _handle_set(args_set: Sequence[str]) -> None:
+    """Handle the ``set`` subcommand.
+
+    Usage: ``bib-lookup set KEY VALUE``
+    ``VALUE`` of ``none``/``null`` resets the key to ``None`` (built-in logic).
+    """
+    if len(args_set) != 2:
+        print("Error: ``set`` accepts exactly 2 arguments: KEY VALUE.")
+        sys.exit(1)
+
+    key, value = args_set
+
+    if key not in _valid_config_keys():
+        verb = "is"
+        warnings.warn(
+            f"Unknown configuration key ``{key}`` {verb} set anyway.",
+            RuntimeWarning,
+        )
+
+    parsed_value = _parse_config_value(value)
+
+    existing = _read_user_config()
+    existing[key] = parsed_value
+    _write_user_config(existing)
+    print(f"Set ``{key}`` to ``{parsed_value}``")
 
 
 def _handle_gather(args: Dict[str, Any]) -> None:
@@ -151,6 +217,13 @@ def _handle_simplify_bib(args: Dict[str, Any]) -> None:
 
 def main():
     """Command-line interface for the bib_lookup package."""
+    # Intercept the ``set`` subcommand before argparse runs,
+    # since the main parser uses a variable-length positional arg
+    # that would otherwise swallow ``set`` as an identifier.
+    if len(sys.argv) > 1 and sys.argv[1] == "set":
+        _handle_set(sys.argv[2:])
+        return
+
     parser = argparse.ArgumentParser(description="Look up a BibTeX entry from a DOI identifier, PMID (URL) or arXiv ID (URL).")
     parser.add_argument(
         "identifiers",

--- a/bib_lookup/styles/gbt7714.py
+++ b/bib_lookup/styles/gbt7714.py
@@ -99,11 +99,13 @@ class GBT7714Style(UnsrtStyle):
         name_style: Optional[Any] = None,
         sorting_style: Optional[Any] = None,
         max_names: int = 3,
+        gbmedium: Optional[bool] = None,
         **kwargs: Any,
     ):
         sorting_style = "none"
         super().__init__(label_style, name_style, sorting_style, **kwargs)
         self.max_names = max_names
+        self.gbmedium = gbmedium
 
     def format_names(self, role: str, as_sentence: bool = True) -> Union[Node, sentence]:
         formatted_names = GBTNames(role, self._format_person, limit=self.max_names)
@@ -133,8 +135,16 @@ class GBT7714Style(UnsrtStyle):
         return f"{surname} {initials}".strip()
 
     def get_article_template(self, e: Entry) -> Node:
-        # Use [J/OL] for online articles (with DOI or URL), [J] for print
-        medium_tag = "[J/OL]" if ("doi" in e.fields or "url" in e.fields) else "[J]"
+        # Determine medium tag per GB/T 7714:
+        #  - gbmedium is True  -> force [J/OL] (online)
+        #  - gbmedium is False -> force [J] (print)
+        #  - gbmedium is None  -> auto-detect from DOI/URL fields
+        if self.gbmedium is True:
+            medium_tag = "[J/OL]"
+        elif self.gbmedium is False:
+            medium_tag = "[J]"
+        else:
+            medium_tag = "[J/OL]" if ("doi" in e.fields or "url" in e.fields) else "[J]"
         template = join(sep=". ")[
             self.format_names("author", as_sentence=False),
             join[field("title"), medium_tag],

--- a/bib_lookup/utils.py
+++ b/bib_lookup/utils.py
@@ -269,26 +269,30 @@ def printmd(md_str: str) -> None:
         print(md_str)  # pragma: no cover
 
 
-def str2bool(v: Union[str, bool, int, float]) -> bool:
+def str2bool(v: Union[str, bool, int, float, None]) -> Union[bool, None]:
     """Converts a "boolean" value possibly in the format of str to bool.
 
     Implementation from StackOverflow [#sa]_.
 
     Parameters
     ----------
-    v : str or bool or int or float
-        The "boolean" value.
+    v : str or bool or int or float or None
+        The "boolean" value. ``None`` is passed through unchanged so that
+        config keys reset to ``None`` (via ``set key none``) keep working
+        for fields that default to ``None`` (e.g. ``gbmedium``).
 
     Returns
     -------
-    bool
-        `v` in the format of bool.
+    bool or None
+        `v` in the format of bool, or ``None`` if `v` is ``None``.
 
     References
     ----------
     .. [#sa] https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
 
     """
+    if v is None:
+        return None
     if isinstance(v, bool):
         b = v
     elif isinstance(v, (int, float)):

--- a/test/test_bib_lookup_handlers.py
+++ b/test/test_bib_lookup_handlers.py
@@ -49,19 +49,32 @@ def test_handle_doi_request_exception(monkeypatch):
 def test_handle_doi_success(monkeypatch):
     bl = BibLookup()
 
-    # return content bytes that decode to "OK"
+    bibtex_content = b"@article{Test_2020,\n  title={Test},\n  author={Author},\n  year={2020}\n}"
+
     def fake_get(**kwargs):
-        return FakeResp(content=b"OK")
+        return FakeResp(content=bibtex_content)
 
     monkeypatch.setattr(bl.session, "get", fake_get, raising=True)
 
     res = bl._handle_doi({"url": "http://example", "headers": {"Accept": "application/x-bibtex"}})
-    # If content starts with @, it returns immediately
-    # But here content is just "OK", which doesn't start with @
-    # So it proceeds to fallback
-    # However, "http://example" does NOT contain "doi.org", so fallback is skipped
-    # And it returns "OK"
-    assert res == "OK"
+    # BibTeX response (starts with @) is returned immediately
+    assert res == bibtex_content.decode("utf-8")
+
+
+def test_handle_doi_html_response_returns_network_error(monkeypatch):
+    """When the server ignores the Accept header and returns HTML,
+    _handle_doi should return network_err instead of the raw HTML."""
+    bl = BibLookup()
+
+    html_content = b'<!DOCTYPE html>\n<html lang="en"><head><meta charset="UTF-8"></head></html>'
+
+    def fake_get(**kwargs):
+        return FakeResp(content=html_content)
+
+    monkeypatch.setattr(bl.session, "get", fake_get, raising=True)
+
+    res = bl._handle_doi({"url": "http://example", "headers": {"Accept": "application/x-bibtex"}})
+    assert res == bl.network_err
 
 
 def test_handle_pm_timeout(monkeypatch):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -273,6 +273,20 @@ def test_cli():
     exitcode, output_msg = execute_cmd(cmd)
     assert not _CONFIG_FILE.exists()
 
+    # --- test that --config KEY=VALUE pairs parse lists, bools, and None ---
+    cmd = """bib-lookup --config "ignore_fields=['url','pdf'];print_result=true;email=none" """
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    assert _CONFIG_FILE.exists()
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["ignore_fields"] == ["url", "pdf"], f"list not parsed: {user_config['ignore_fields']}"
+    assert user_config["print_result"] is True, f"bool not parsed: {user_config['print_result']}"
+    assert user_config["email"] is None, f"none not parsed: {user_config['email']}"
+
+    cmd = "bib-lookup --config reset"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert not _CONFIG_FILE.exists()
+
     # --- test that --config warns on unknown keys (instead of silent discard) ---
     if _CONFIG_FILE.exists():
         _CONFIG_FILE.rename(_CONFIG_FILE.with_suffix(".bak"))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -226,6 +226,77 @@ def test_cli():
     assert exitcode == 0
     # output_msg should contain something if successful.
 
+    # --- tests for the ``set`` subcommand ---
+    # set a single key (value is stored as string; BibLookup coerces on read)
+    cmd = "bib-lookup set timeout 5.0"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    assert _CONFIG_FILE.exists()
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["timeout"] == "5.0"
+
+    # set with boolean value
+    cmd = "bib-lookup set print_result true"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["print_result"] is True
+
+    # set with none resets to None
+    cmd = "bib-lookup set print_result none"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["print_result"] is None
+
+    # set gbmedium (style-specific key)
+    cmd = "bib-lookup set gbmedium true"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["gbmedium"] is True
+
+    # set with unknown key should warn but succeed
+    cmd = "bib-lookup set totally_unknown_key value"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    output_text = "".join(output_msg)
+    assert "Unknown" in output_text or "unknown" in output_text
+
+    # set with wrong number of arguments should fail
+    cmd = "bib-lookup set only_one_arg"
+    exitcode, output_msg = execute_cmd(cmd, raise_error=False)
+    assert exitcode == 1
+
+    # clean up
+    cmd = "bib-lookup --config reset"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert not _CONFIG_FILE.exists()
+
+    # --- test that --config warns on unknown keys (instead of silent discard) ---
+    if _CONFIG_FILE.exists():
+        _CONFIG_FILE.rename(_CONFIG_FILE.with_suffix(".bak"))
+        config_backed_file2 = _CONFIG_FILE.with_suffix(".bak")
+    else:
+        config_backed_file2 = None
+
+    cmd = """bib-lookup --config "timeout=2.0;unknown_key=foo" """
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    output_text = "".join(output_msg)
+    assert "Unknown" in output_text or "unknown" in output_text
+    # the valid key should still be written (as string; BibLookup coerces on read)
+    assert _CONFIG_FILE.exists()
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    assert user_config["timeout"] == "2.0"
+
+    cmd = "bib-lookup --config reset"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert not _CONFIG_FILE.exists()
+
+    if config_backed_file2 is not None:
+        config_backed_file2.rename(_CONFIG_FILE)
+
     # restore the original config file
     if config_backed_file is not None:
         config_backed_file.rename(_CONFIG_FILE)

--- a/test/test_styles.py
+++ b/test/test_styles.py
@@ -601,6 +601,45 @@ def test_gbmedium():
     assert "[J/OL]" in result_online_nodoi, f"gbmedium=True without DOI should force [J/OL], got: {result_online_nodoi}"
 
 
+def test_handle_doi_returns_network_error_on_html_response(monkeypatch):
+    """When Crossref returns HTML instead of BibTeX (200 OK but wrong content),
+    _handle_doi should return network_err, not the raw HTML.  Otherwise the
+    parser gets 'list index out of range' on HTML input."""
+    from bib_lookup import BibLookup
+
+    HTML_RESPONSE = (
+        '<!DOCTYPE html>\n<html lang="en" class="no-js">\n'
+        '    <head><meta charset="UTF-8"></head>\n'
+        "    <body><h1>Not Found</h1></body>\n</html>"
+    )
+
+    def _fake_obtain(self, identifier, arxiv2doi=None, format=None, style=None, timeout=None):
+        return (
+            "doi",
+            {"url": "https://doi.org/10.1234/test", "timeout": 10, "headers": {"Accept": "application/x-bibtex"}},
+            "10.1234/test",
+        )
+
+    def _fake_handle(self, feed_content):
+        # Pretend we got a 200 OK with HTML content
+        # by monkeypatching session.get directly
+        pass
+
+    import requests
+
+    class _FakeResponse:
+        status_code = 200
+        content = HTML_RESPONSE.encode("utf-8")
+        url = "https://doi.org/10.1234/test"
+        text = HTML_RESPONSE
+
+    monkeypatch.setattr(requests.Session, "get", lambda *a, **kw: _FakeResponse())
+
+    bl = BibLookup(verbose=0)
+    result = bl("10.1234/test", timeout=10)
+    assert "Network Error" in result, f"Expected Network Error for HTML response, got: {result!r}"
+
+
 def test_gbmedium_via_biblookup(monkeypatch):
     """End-to-end: ``gbmedium`` set via config propagates to GBT7714Style."""
     from bib_lookup import BibLookup

--- a/test/test_styles.py
+++ b/test/test_styles.py
@@ -540,6 +540,103 @@ def test_additional_coverage():
     assert _r(gbt_year_vol_pages, entry_year_only3) == "2021"
 
 
+def test_gbmedium():
+    """Test that ``gbmedium`` controls the ``[J]`` vs ``[J/OL]`` tag in GBT7714."""
+    from pybtex.database import parse_string
+
+    # Entry with DOI — auto-detect would give [J/OL]
+    entry_with_doi = """@article{test_gbmedium,
+        title={Test Title},
+        author={Wen, Hao},
+        journal={Test Journal},
+        year={2022},
+        doi={10.1234/test},
+        volume={1},
+        pages={100}
+    }"""
+    bib_data = parse_string(entry_with_doi, bib_format="bibtex", encoding="utf-8")
+    entry = list(bib_data.entries.values())[0]
+
+    ctx = {"entry": entry, "bib_data": bib_data}
+
+    # gbmedium=None (default) — auto-detect: DOI present → [J/OL]
+    style_default = GBT7714Style()
+    result_default = str(style_default.get_article_template(entry).format_data(ctx)).strip()
+    assert "[J/OL]" in result_default, f"auto-detect with DOI should give [J/OL], got: {result_default}"
+
+    # gbmedium=True — force [J/OL]
+    style_online = GBT7714Style(gbmedium=True)
+    result_online = str(style_online.get_article_template(entry).format_data(ctx)).strip()
+    assert "[J/OL]" in result_online, f"gbmedium=True should give [J/OL], got: {result_online}"
+
+    # gbmedium=False — force [J]
+    style_print = GBT7714Style(gbmedium=False)
+    result_print = str(style_print.get_article_template(entry).format_data(ctx)).strip()
+    assert (
+        "[J]" in result_print and "[J/OL]" not in result_print
+    ), f"gbmedium=False should give [J] (not [J/OL]), got: {result_print}"
+
+    # Entry without DOI — auto-detect would give [J]
+    entry_no_doi = """@article{test_gbmedium_nodoi,
+        title={Test Title},
+        author={Wen, Hao},
+        journal={Test Journal},
+        year={2022},
+        volume={1},
+        pages={100}
+    }"""
+    bib_data_nodoi = parse_string(entry_no_doi, bib_format="bibtex", encoding="utf-8")
+    entry_nodoi = list(bib_data_nodoi.entries.values())[0]
+    ctx_nodoi = {"entry": entry_nodoi, "bib_data": bib_data_nodoi}
+
+    style_default_nodoi = GBT7714Style()
+    result_nodoi = str(style_default_nodoi.get_article_template(entry_nodoi).format_data(ctx_nodoi)).strip()
+    assert (
+        "[J]" in result_nodoi and "[J/OL]" not in result_nodoi
+    ), f"auto-detect without DOI should give [J], got: {result_nodoi}"
+
+    # gbmedium=True forces [J/OL] even without DOI
+    style_online_nodoi = GBT7714Style(gbmedium=True)
+    result_online_nodoi = str(style_online_nodoi.get_article_template(entry_nodoi).format_data(ctx_nodoi)).strip()
+    assert "[J/OL]" in result_online_nodoi, f"gbmedium=True without DOI should force [J/OL], got: {result_online_nodoi}"
+
+
+def test_gbmedium_via_biblookup(monkeypatch):
+    """End-to-end: ``gbmedium`` set via config propagates to GBT7714Style."""
+    from bib_lookup import BibLookup
+
+    RAW = """@article{Wen_2022,
+        title={Test Title},
+        author={Wen, Hao},
+        journal={Test Journal},
+        year={2022},
+        doi={10.1234/test},
+        volume={1},
+        pages={100}
+    }"""
+
+    def _fake_obtain(self, identifier, arxiv2doi=None, format=None, style=None, timeout=None):
+        return ("doi", {}, "10.1234/test")
+
+    def _fake_handle(self, feed_content):
+        return RAW
+
+    monkeypatch.setattr(BibLookup, "_obtain_feed_content", _fake_obtain)
+    monkeypatch.setattr(BibLookup, "_handle_doi", _fake_handle)
+
+    # gbmedium=True → [J/OL]
+    bl_online = BibLookup(gbmedium=True, verbose=0)
+    result = bl_online("10.1234/test", format="text", style="gbt", print_result=False)
+    assert "[J/OL]" in result, f"gbmedium=True via BibLookup should give [J/OL], got: {result}"
+
+    # gbmedium=False → [J]
+    bl_print = BibLookup(gbmedium=False, verbose=0)
+    result_print = bl_print("10.1234/test", format="text", style="gbt", print_result=False)
+    assert (
+        "[J]" in result_print and "[J/OL]" not in result_print
+    ), f"gbmedium=False via BibLookup should give [J], got: {result_print}"
+
+
 def test_misc():
     with pytest.raises(ValueError):
         GBTNames("author", str, limit=0)


### PR DESCRIPTION
## Summary
- Add `gbmedium` config option for GB/T 7714 style: `True` forces `[J/OL]`, `False` forces `[J]`, `None` (default) auto-detects from DOI/URL fields
- Add `bib-lookup set KEY VALUE` subcommand for setting individual config values (`none`/`null` resets to `None`)
- `--config` now warns on unknown keys instead of silently discarding them (keys are still written)
- Refactor: style-specific settings collected in `_style_kwargs` dict via `_init_style_kwargs`, making it easy to add new per-style parameters
- `str2bool` now passes `None` through so config keys reset to `None` work for boolean fields