### PR TITLE
fix: correct --timeout type, replace asserts, add --style choices

### DIFF
--- a/bib_lookup/cli.py
+++ b/bib_lookup/cli.py
@@ -307,7 +307,7 @@ def main():
     parser.add_argument(
         "--timeout",
         type=float,
-        default=6,
+        default=6.0,
         help="Timeout for the lookup request. Unit is seconds. Default is 6 seconds.",
         dest="timeout",
     )
@@ -330,10 +330,10 @@ def main():
     )
     parser.add_argument(
         "--style",
-        type=str,
+        type=str.lower,
         help="Style of the output, valid only when 'format' is 'text', optional.",
         dest="style",
-        choices=list(BibLookup._get_supported_styles().keys()),
+        choices=sorted(BibLookup._get_supported_styles().keys()),
     )
     parser.add_argument(
         "--verbose",

--- a/bib_lookup/cli.py
+++ b/bib_lookup/cli.py
@@ -97,7 +97,8 @@ def _handle_config(config_arg: str) -> None:
         else:
             config_path = Path(config_arg)
             if not config_path.is_file():
-                raise ValueError(f"Configuration file ``{config_arg}`` does not exist. Please check and try again.")
+                print(f"Error: Configuration file ``{config_arg}`` does not exist. Please check and try again.")
+                sys.exit(1)
 
             if config_path.suffix == ".json":
                 config = json.loads(config_path.read_text())
@@ -305,7 +306,7 @@ def main():
     )
     parser.add_argument(
         "--timeout",
-        type=int,
+        type=float,
         default=6,
         help="Timeout for the lookup request. Unit is seconds. Default is 6 seconds.",
         dest="timeout",
@@ -332,6 +333,7 @@ def main():
         type=str,
         help="Style of the output, valid only when 'format' is 'text', optional.",
         dest="style",
+        choices=list(BibLookup._get_supported_styles().keys()),
     )
     parser.add_argument(
         "--verbose",
@@ -424,7 +426,9 @@ def main():
         bl.check_bib_file(check_file)
         return
     else:
-        assert len(args["identifiers"]) > 0 or args["input_file"] is not None, "No identifiers given."
+        if len(args["identifiers"]) == 0 and args["input_file"] is None:
+            print("Error: No identifiers given.")
+            sys.exit(1)
 
     extra_kw = {}
     if args["format"] is not None and args["format"] not in ["bibtex", "bibentry"]:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -287,6 +287,46 @@ def test_cli():
     exitcode, output_msg = execute_cmd(cmd)
     assert not _CONFIG_FILE.exists()
 
+    # --- test --config with non-existent config file fails with exit code 1 ---
+    cmd = "bib-lookup --config /nonexistent/path/to/config.json"
+    exitcode, output_msg = execute_cmd(cmd, raise_error=False)
+    assert exitcode == 1
+
+    # --- test bib-lookup with no identifiers and no input file fails with exit code 1 ---
+    cmd = "bib-lookup"
+    exitcode, output_msg = execute_cmd(cmd, raise_error=False)
+    assert exitcode == 1
+    output_text = "".join(output_msg)
+    assert "No identifiers" in output_text or "Error" in output_text
+
+    # --- test --style with invalid value is rejected by argparse ---
+    cmd = "bib-lookup 10.1109/CVPR.2016.90 --format text --style totally_invalid_style"
+    exitcode, output_msg = execute_cmd(cmd, raise_error=False)
+    assert exitcode != 0  # argparse exits with code 2 for invalid choice
+
+    # --- test --style with uppercase value is accepted (type=str.lower) ---
+    cmd = "bib-lookup 10.1142/S1005386718000305 --format text --style APA --timeout 10 --ignore-errors"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+
+    # --- test that --timeout accepts float values ---
+    cmd = "bib-lookup --config 'timeout=7.5'"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert exitcode == 0
+    assert _CONFIG_FILE.exists()
+    user_config = json.loads(_CONFIG_FILE.read_text())
+    # _parse_config_value stores as string; BibLookup coerces to float on read
+    assert user_config["timeout"] == "7.5", f"timeout not stored correctly: {user_config['timeout']}"
+    # Verify BibLookup correctly reads and coerces the float
+    from bib_lookup import BibLookup
+
+    bl = BibLookup()
+    assert bl.timeout == 7.5, f"timeout not coerced to float: {bl.timeout}"
+    # clean up
+    cmd = "bib-lookup --config reset"
+    exitcode, output_msg = execute_cmd(cmd)
+    assert not _CONFIG_FILE.exists()
+
     # --- test that --config warns on unknown keys (instead of silent discard) ---
     if _CONFIG_FILE.exists():
         _CONFIG_FILE.rename(_CONFIG_FILE.with_suffix(".bak"))


### PR DESCRIPTION
## Summary
- **P0**: Change `--timeout` from `type=int` to `type=float` to match `DEFAULT_CONFIG` (`6.0`) and `BibLookup`'s `float()` cast, preventing silent truncation of values like `6.5`
- **P1**: Replace `assert` statements in `_handle_config` and `main()` with explicit error messages + `sys.exit(1)`, so validation is not skipped under `python -O`
- **P2**: Add `choices=[...]` to `--style` argument, populated from `BibLookup._get_supported_styles()`, so invalid styles are caught at argument-parse time